### PR TITLE
fix: slow add_shp in cartopy v0.23

### DIFF
--- a/cinrad/visualize/utils.py
+++ b/cinrad/visualize/utils.py
@@ -17,7 +17,9 @@ import matplotlib.cm as mcm
 from cartopy.io import shapereader
 import cartopy.crs as ccrs
 from cartopy.mpl.geoaxes import GeoAxes
+from cartopy.feature import Feature
 import shapefile
+import shapely.geometry as sgeom
 from vanadis.colormap import Colormap
 from cinrad_data import get_font_path, get_shp_list, get_shp_file
 
@@ -138,9 +140,9 @@ cbar_text = {"REF":None, "VEL":["RF", "", "27", "20", "15", "10", "5", "1", "0",
                      "0.9", "0.7", "0.5", "0.3", "0.1"],
              "OHP":["", "203.2", "152.4", "101.6", "76.2", "63.5", "50.8", "44.45", "38.1", "31.75",
                     "25.4", "19.05", "12.7", "6.35", "2.54", "0"],
-             "cHCL":["Drizzle", "Rain", "Ice Crystals", "Dry Snow", "Wet Snow", "Vertical Ice", 
+             "cHCL":["Drizzle", "Rain", "Ice Crystals", "Dry Snow", "Wet Snow", "Vertical Ice",
                      "Low-Dens Graupel", "High-Dens Graupel", "Hail", "Big Drops", ""],
-             "HCL":["Rain", "Heavy Rain", "Hail", "Big Drops", "Clear-Air Echo", "Ground Clutter", 
+             "HCL":["Rain", "Heavy Rain", "Hail", "Big Drops", "Clear-Air Echo", "Ground Clutter",
                     "Dry snow", "Wet snow", "Ice Crystals", "Graupel", "Unknown", ""]}
 # fmt: on
 
@@ -272,6 +274,19 @@ def get_shp() -> list:
     return shps
 
 
+class _ShapelyFeature(Feature):
+    r"""Copied from cartopy.feature.ShapelyFeature"""
+
+    def __init__(self, geometries, crs, **kwargs):
+        super().__init__(crs, **kwargs)
+        if isinstance(geometries, sgeom.base.BaseGeometry):
+            geometries = [geometries]
+        self._geoms = tuple(geometries)
+
+    def geometries(self):
+        return iter(self._geoms)
+
+
 def add_shp(
     ax: Any,
     proj: ccrs.Projection,
@@ -287,29 +302,35 @@ def add_shp(
         line_colors = ["grey", "lightgrey", "white"]
     elif style == "white":
         line_colors = ["lightgrey", "grey", "black"]
-    ax.add_geometries(
-        shps[0],
-        shp_crs,
-        edgecolor=line_colors[0],
-        facecolor="None",
-        zorder=3,
-        linewidth=0.5,
+    ax.add_feature(
+        _ShapelyFeature(
+            shps[0],
+            shp_crs,
+            edgecolor=line_colors[0],
+            facecolor="None",
+            zorder=3,
+            linewidth=0.5,
+        )
     )
-    ax.add_geometries(
-        shps[1],
-        shp_crs,
-        edgecolor=line_colors[1],
-        facecolor="None",
-        zorder=3,
-        linewidth=0.7,
+    ax.add_feature(
+        _ShapelyFeature(
+            shps[1],
+            shp_crs,
+            edgecolor=line_colors[1],
+            facecolor="None",
+            zorder=3,
+            linewidth=0.7,
+        )
     )
-    ax.add_geometries(
-        shps[2],
-        shp_crs,
-        edgecolor=line_colors[2],
-        facecolor="None",
-        zorder=3,
-        linewidth=1,
+    ax.add_feature(
+        _ShapelyFeature(
+            shps[2],
+            shp_crs,
+            edgecolor=line_colors[2],
+            facecolor="None",
+            zorder=3,
+            linewidth=1,
+        )
     )
     if coastline:
         ax.coastlines(resolution="10m", color=line_colors[2], zorder=3, linewidth=1)


### PR DESCRIPTION
`cartopy<=0.22` 时 `FeatureArtist.draw` 只会投影和绘制与 `GeoAxes` 的 `extent` 方框有交点的几何对象，但 0.23 的 [PR#2323](https://github.com/SciTools/cartopy/pull/2323) 新增了判断分支：如果 `feature` 是 `ShapelyFeature`，那么不会做跳过方框外的几何对象的处理，会对 `city.shp` 里的所有内容做投影和绘制，而等距圆柱投影到等距方位投影的转换特别耗时。

提交的修改是在 `cinrad.visualize.utils` 里复制一份功能跟 `ShapelyFeature` 相同，但类型不一样的 `Feature` 类，这样就能触发跳过方框外几何对象的分支，让画图速度恢复到 `cartopy<=0.22` 的水平。