### PR TITLE
feat: Add height filtering to StandardData and optimize quick_cr

### DIFF
--- a/test/test_calc.py
+++ b/test/test_calc.py
@@ -56,3 +56,155 @@ def test_et_cy2py():
     et2 = echo_top_py(a, b, c, 0)
 
     assert np.array_equal(et, et2)
+
+# --- Tests for quick_cr ---
+import xarray as xr
+from cinrad.calc import quick_cr
+from cinrad.grid import grid_2d # Used for reference calculation
+
+def _create_sample_rlist_for_quick_cr(num_tilts: int, common_shape=(3, 4), resolution=(1.0, 1.0)):
+    """
+    Creates a list of xr.Dataset objects mimicking radar tilts for quick_cr testing.
+    """
+    r_list = []
+    
+    # Define common longitude and latitude grids for simplicity
+    # These would typically be 2D arrays from radar projection
+    # For grid_2d, input lon/lat are N_az x N_gates.
+    # Let's assume polar data that will be gridded.
+    # For testing quick_cr, the actual projection details are less critical than
+    # having REF, longitude, latitude fields that grid_2d can process.
+
+    # Mocking values as if they came from radar projection (polar -> cartesian-like for grid_2d)
+    # grid_2d expects longitude and latitude to be 2D (azimuth, distance)
+    n_azimuths = 10
+    n_gates = 5
+    
+    base_lon = np.linspace(120, 120.1, n_gates)
+    base_lat = np.linspace(30, 30.1, n_gates)
+
+    # Create common target grid for simpler reference calculation
+    # This is what x_out, y_out in grid_2d would be based on resolution
+    # For simplicity, let's make the gridded output shape `common_shape`
+
+    for i in range(num_tilts):
+        # Create slightly different REF data for each tilt
+        ref_data = np.full((n_azimuths, n_gates), 10.0 * (i + 1), dtype=float)
+        if i % 2 == 0:
+            ref_data[i % n_azimuths, i % n_gates] = np.nan # Introduce some NaNs
+            ref_data[(i+1) % n_azimuths, (i+1) % n_gates] = 50.0 + i # Some varying values
+        else:
+            ref_data[i % n_azimuths, i % n_gates] = 5.0 * (i + 1)
+            ref_data[(i+1) % n_azimuths, (i+1) % n_gates] = np.nan
+
+
+        # Mock longitude/latitude data (could be more realistic if needed)
+        # These should be 2D arrays [n_azimuths, n_gates]
+        lon_vals = np.array([base_lon + 0.01 * i] * n_azimuths)
+        lat_vals = np.array([base_lat + 0.01 * i] * n_azimuths)
+
+        ds_attrs = {
+            "scan_time": f"2024-01-01T0{i}:00:00Z",
+            "site_name": f"TestSite_Tilt{i}",
+            "unique_attr_tilt0": "present" if i == 0 else "absent"
+        }
+        
+        tilt_ds = xr.Dataset(
+            data_vars={
+                "REF": (("azimuth", "distance"), ref_data),
+                "longitude": (("azimuth", "distance"), lon_vals),
+                "latitude": (("azimuth", "distance"), lat_vals),
+            },
+            coords={
+                "azimuth": np.linspace(0, 350, n_azimuths),
+                "distance": np.linspace(1, n_gates, n_gates)
+            },
+            attrs=ds_attrs
+        )
+        r_list.append(tilt_ds)
+    return r_list
+
+def test_quick_cr_numerical_consistency_and_attrs():
+    """
+    Tests quick_cr for numerical consistency with a reference calculation (np.nanmax)
+    and checks attribute handling.
+    """
+    resolution = (0.05, 0.05) # Resolution for gridding, degrees for lat/lon
+
+    # Test with multiple tilts
+    r_list_multi_tilt = _create_sample_rlist_for_quick_cr(num_tilts=3, resolution=resolution)
+    
+    # --- Reference Calculation ---
+    gridded_tilts_ref = []
+    x_grid_ref, y_grid_ref = None, None
+
+    # First tilt to establish the grid
+    r0, x0, y0 = grid_2d(
+        r_list_multi_tilt[0]["REF"].values,
+        r_list_multi_tilt[0]["longitude"].values,
+        r_list_multi_tilt[0]["latitude"].values,
+        resolution=resolution
+    )
+    gridded_tilts_ref.append(r0)
+    x_grid_ref, y_grid_ref = x0, y0
+    
+    for tilt_ds in r_list_multi_tilt[1:]:
+        r_gridded, _, _ = grid_2d(
+            tilt_ds["REF"].values,
+            tilt_ds["longitude"].values,
+            tilt_ds["latitude"].values,
+            x_out=x_grid_ref,
+            y_out=y_grid_ref,
+            resolution=resolution
+        )
+        gridded_tilts_ref.append(r_gridded)
+    
+    reference_cr_data = np.nanmax(np.stack(gridded_tilts_ref, axis=0), axis=0)
+
+    # --- Current quick_cr Calculation ---
+    result_ds_multi = quick_cr(r_list_multi_tilt, resolution=resolution)
+
+    # --- Assertions for multiple tilts ---
+    assert "CR" in result_ds_multi
+    np.testing.assert_allclose(
+        result_ds_multi["CR"].data, reference_cr_data, nan_equal=True,
+        err_msg="quick_cr output differs from np.nanmax reference for multiple tilts"
+    )
+    assert result_ds_multi.attrs["elevation"] == 0
+    # Check if attributes are from the first tilt (r_list[0])
+    assert result_ds_multi.attrs["site_name"] == r_list_multi_tilt[0].attrs["site_name"]
+    assert result_ds_multi.attrs["unique_attr_tilt0"] == "present"
+
+
+    # Test with a single tilt (covers the attribute bug fix)
+    r_list_single_tilt = _create_sample_rlist_for_quick_cr(num_tilts=1, resolution=resolution)
+    
+    # Reference for single tilt is just the gridded first tilt
+    reference_cr_single_data, _, _ = grid_2d(
+        r_list_single_tilt[0]["REF"].values,
+        r_list_single_tilt[0]["longitude"].values,
+        r_list_single_tilt[0]["latitude"].values,
+        resolution=resolution
+    )
+
+    result_ds_single = quick_cr(r_list_single_tilt, resolution=resolution)
+    
+    # --- Assertions for single tilt ---
+    assert "CR" in result_ds_single
+    np.testing.assert_allclose(
+        result_ds_single["CR"].data, reference_cr_single_data, nan_equal=True,
+        err_msg="quick_cr output differs from gridded single tilt for single tilt input"
+    )
+    assert result_ds_single.attrs["elevation"] == 0
+    assert result_ds_single.attrs["site_name"] == r_list_single_tilt[0].attrs["site_name"]
+    assert result_ds_single.attrs["unique_attr_tilt0"] == "present"
+
+    # Test with empty r_list (should raise ValueError due to @require or internal check)
+    # Note: @require decorator should catch this. If not, the internal check in quick_cr will.
+    # This test might be more for the decorator or initial checks than quick_cr's core logic.
+    # import pytest # Add to top imports if not there
+    # with pytest.raises(ValueError):
+    #    quick_cr([], resolution=resolution) 
+    # This test for empty list is commented out as @require handles it, and this test
+    # focuses on numerical consistency of the main algorithm and attribute handling.
+    # If @require was not present, the explicit check `if not r_list:` in quick_cr would be tested.

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -50,3 +50,144 @@ def test_missing_radar_type():
     fake_file = BytesIO(fill)
     with pytest.raises(RadarDecodeError):
         CinradReader(fake_file)
+
+# --- Tests for StandardData.get_data height filtering ---
+import numpy as np
+import xarray as xr
+from unittest.mock import MagicMock, PropertyMock, patch
+import datetime
+
+from cinrad.io.level2 import StandardData # Actual class to test method from
+
+# Helper to create a mock StandardData instance configured for get_data tests
+def _create_mock_sd_for_get_data(ref_data_shape, height_values, scan_type="PPI", tilt_idx=0):
+    mock_sd = MagicMock(spec=StandardData)
+
+    # Attributes StandardData.get_data relies on
+    mock_sd.scan_config = [MagicMock(dop_reso=0.001, log_reso=0.001, nyquist_spd=25.0)] # reso in km for calculations
+    mock_sd.code = "TEST"
+    mock_sd.name = "TestRadar"
+    mock_sd.stationlon = 120.0
+    mock_sd.stationlat = 30.0
+    mock_sd.scantime = datetime.datetime(2024, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
+    mock_sd.task_name = "SCAN_TASK"
+    mock_sd.scan_type = scan_type
+    
+    # Mock radarheight (in km for the height() function)
+    # Using type() to mock a property on an instance
+    type(mock_sd).radarheight = PropertyMock(return_value=0.1) # 100m in km
+
+    # Mock get_raw: returns the primary data array (e.g., 'REF')
+    # The values of this array will be checked after filtering.
+    # Using a simple np.ones array, but could be more complex.
+    raw_data_array = np.ones(ref_data_shape, dtype=float)
+    mock_sd.get_raw.return_value = raw_data_array
+
+    if scan_type == "PPI":
+        mock_sd.elev = 0.5 # degrees, general elevation for this tilt
+        # Mock projection: returns x, y, z (height_values), d, a
+        # These are geographical coordinates. height_values are key for the test.
+        x_coords = np.zeros(ref_data_shape)
+        y_coords = np.zeros(ref_data_shape)
+        # distance and azimuth coords, matching shape
+        dist_coords = np.arange(ref_data_shape[1], dtype=float) 
+        az_coords = np.arange(ref_data_shape[0], dtype=float)
+        mock_sd.projection.return_value = (x_coords, y_coords, height_values, dist_coords, az_coords)
+    
+    elif scan_type == "RHI":
+        # For RHI, elevs are per-ray, not a single value for the tilt.
+        # self.el[tilt_idx] is used for attributes.
+        mock_sd.el = [0.5, 1.5, 2.5] # Example elevation angles for RHI
+        
+        # aux structure for RHI:
+        # aux[tilt_idx]['azimuth'] is a list/array of one azimuth
+        # aux[tilt_idx]['elevation'] contains the elevation angles for each ray in this RHI scan.
+        # These 'elevation' values are used to compute height (y_cor) in RHI.
+        # The shape of height_values for RHI should match ref_data_shape.
+        # The test will patch `cinrad.io.level2.height` to control these heights.
+        mock_sd.aux = {
+            tilt_idx: {
+                'azimuth': [30.0], # Fixed azimuth for RHI
+                'elevation': np.linspace(0.5, 10.0, ref_data_shape[0]) # Vertical dimension "tilts"
+            }
+        }
+    return mock_sd
+
+def test_standard_data_get_data_ppi_height_filtering():
+    ref_shape = (2, 5) # 2 azimuths, 5 gates
+    # Heights: one row within (1.0, 2.0), one row outside
+    height_values = np.array([[1.0, 1.2, 1.5, 1.8, 1.9],   # Kept by filter (1.0, 2.0)
+                              [2.1, 2.2, 2.5, 2.8, 3.0]])  # NaNed by filter (1.0, 2.0)
+    
+    mock_sd_ppi = _create_mock_sd_for_get_data(ref_shape, height_values, scan_type="PPI")
+
+    tilt_idx, drange_km, dtype_str = 0, 5.0, "REF"
+
+    # Case 1: Filter (1.0, 2.0)
+    height_range1 = (1.0, 2.0)
+    ds1 = StandardData.get_data(mock_sd_ppi, tilt_idx, drange_km, dtype_str, height_range=height_range1)
+    expected_data1 = np.array([[1., 1., 1., 1., 1.],
+                               [np.nan, np.nan, np.nan, np.nan, np.nan]])
+    np.testing.assert_array_equal(ds1[dtype_str].values, expected_data1)
+    assert "height" in ds1.coords # Height coordinate should exist
+
+    # Case 2: No filter (height_range is None)
+    ds2 = StandardData.get_data(mock_sd_ppi, tilt_idx, drange_km, dtype_str, height_range=None)
+    expected_data2 = np.ones(ref_shape) # Original data from get_raw mock
+    np.testing.assert_array_equal(ds2[dtype_str].values, expected_data2)
+    assert "height" in ds2.coords
+
+    # Case 3: Filter excludes all data
+    height_range3 = (5.0, 6.0) # Assuming all height_values are < 5.0
+    ds3 = StandardData.get_data(mock_sd_ppi, tilt_idx, drange_km, dtype_str, height_range=height_range3)
+    expected_data3 = np.full(ref_shape, np.nan)
+    np.testing.assert_array_equal(ds3[dtype_str].values, expected_data3)
+
+    # Case 4: Filter min_h > max_h
+    height_range4 = (3.0, 1.0)
+    ds4 = StandardData.get_data(mock_sd_ppi, tilt_idx, drange_km, dtype_str, height_range=height_range4)
+    np.testing.assert_array_equal(ds4[dtype_str].values, expected_data3) # Should also be all NaN
+
+
+@patch('cinrad.io.level2.height') # Patch the imported height function in level2.py
+def test_standard_data_get_data_rhi_height_filtering(mock_projection_height):
+    ref_shape = (3, 5) # 3 RHI "elevation sweeps", 5 gates
+    
+    # These are the heights that our patched `cinrad.io.level2.height` will return.
+    # This gives us direct control over the `h` variable in `get_data` for RHI.
+    controlled_rhi_heights = np.array([
+        [0.5, 0.6, 0.7, 0.8, 0.9],  # Row 0: To be NaNed by filter (1.0, 1.5)
+        [1.0, 1.1, 1.2, 1.3, 1.4],  # Row 1: To be kept by filter (1.0, 1.5)
+        [1.6, 1.7, 1.8, 1.9, 2.0]   # Row 2: To be NaNed by filter (1.0, 1.5)
+    ])
+    mock_projection_height.return_value = controlled_rhi_heights
+    
+    mock_sd_rhi = _create_mock_sd_for_get_data(ref_shape, None, scan_type="RHI") # height_values not used by RHI mock setup here
+
+    tilt_idx, drange_km, dtype_str = 0, 5.0, "REF"
+    
+    # Case 1: Filter (1.0, 1.5) for RHI
+    # Note: The filter is inclusive: ds.height >= min_h and ds.height <= max_h
+    height_range_rhi1 = (1.0, 1.5) 
+    ds_rhi1 = StandardData.get_data(mock_sd_rhi, tilt_idx, drange_km, dtype_str, height_range=height_range_rhi1)
+
+    mock_projection_height.assert_called_once() # Ensure our patched height function was used
+
+    # Original data is np.ones(ref_shape) due to _create_mock_sd_for_get_data -> get_raw
+    expected_data_rhi1 = np.full(ref_shape, np.nan)
+    expected_data_rhi1[1, :] = 1.0 # Middle row (index 1) corresponds to heights 1.0-1.4
+    
+    np.testing.assert_array_equal(ds_rhi1[dtype_str].values, expected_data_rhi1)
+    assert "height" in ds_rhi1.coords # ds.height should be populated from y_cor
+    assert "y_cor" in ds_rhi1.coords # y_cor should also be there for RHI
+
+    # Case 2: RHI with no filter
+    # Need to reset mock call count if checking per call, or just let it be.
+    # For simplicity, we are not checking call count for the no-filter case here.
+    # The important part is that the data is not filtered.
+    mock_projection_height.return_value = controlled_rhi_heights # Ensure it's set for this call too
+    ds_rhi2 = StandardData.get_data(mock_sd_rhi, tilt_idx, drange_km, dtype_str, height_range=None)
+    expected_data_rhi2 = np.ones(ref_shape)
+    np.testing.assert_array_equal(ds_rhi2[dtype_str].values, expected_data_rhi2)
+    assert "height" in ds_rhi2.coords
+    assert ds_rhi2.height.shape == ref_shape


### PR DESCRIPTION
This commit introduces two main changes:

1.  Height Filtering for `StandardData`:
    - The `StandardData.get_data` method now accepts an optional `height_range` (tuple of min/max height in km) parameter. If you provide it, the output xarray.Dataset is filtered to mask data outside this height range. This is achieved using `ds.where()` based on the `ds.height` coordinate.
    - For RHI scans, where `ds.height` might not be directly populated in the same way as PPI, I use `ds.y_cor` (which represents height in RHI) to create `ds.height` before filtering if `height_range` is specified.
    - I've also updated the `StandardData.iter_tilt` method to accept and pass through the `height_range` parameter to `get_data`.
    - I've added unit tests to verify the height filtering functionality for both PPI and RHI scan types, using mocked `StandardData` objects to ensure test isolation and cover various filtering scenarios.

2.  Memory Optimization for `cinrad.calc.quick_cr`:
    - I've optimized the `quick_cr` function, which calculates composite reflectivity, for memory efficiency.
    - Previously, it would grid each radar tilt, store all gridded 2D arrays in a list, and then compute `np.nanmax` across this list. This could lead to high peak memory usage for datasets with many tilts or high resolution.
    - The updated implementation grids the first tilt to initialize the composite reflectivity array. Subsequent tilts are then gridded one by one, and the composite reflectivity array is updated iteratively using `np.fmax`. This avoids storing all intermediate gridded arrays in memory simultaneously.
    - I fixed a bug in `quick_cr` related to attribute assignment (`ret.attrs = i.attrs`) when the input `r_list` had only one item. Attributes are now consistently copied from `r_list[0].attrs`.
    - I've added unit tests to verify that the optimized `quick_cr` produces numerically identical results to the previous method and that dataset attributes are handled correctly, including for single-tilt inputs.