### PR TITLE
fix: add NumPy 2.x and MinGW build support

### DIFF
--- a/cinrad/_utils.pyx
+++ b/cinrad/_utils.pyx
@@ -1,8 +1,12 @@
 # cython: language_level=3
+# cython: c_api_binop_methods=True
 # Author: PyCINRAD Developers
+
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 
 cimport numpy as np
 import numpy as np
+np.import_array()
 cimport cython
 from libc.math cimport sin
 

--- a/cinrad/correct/_unwrap_2d.pyx
+++ b/cinrad/correct/_unwrap_2d.pyx
@@ -1,3 +1,12 @@
+# cython: language_level=3
+# cython: c_api_binop_methods=True
+
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+
+cimport numpy as np
+import numpy as np
+np.import_array()
+
 cdef extern from "unwrap_2d_ljmu.c":
     void unwrap2D(double* wrapped_image,
                   double* unwrapped_image,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-numpy
-cython>0.15
+numpy>=1.20
+cython>=0.29.21
 metpy>=0.8
 cartopy>=0.15
 pyshp!=2.0.0, !=2.0.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,25 @@
+# setup.cfg
+# 
+# Build and Installation Instructions:
+#
+# Windows (MinGW-w64):
+#   1. Build: python setup.py build_ext --inplace --compiler=mingw32
+#   2. Install: pip install -e . --no-build-isolation
+#
+# Windows (MSVC) / Linux / MacOS:
+#   1. Build: python setup.py build_ext --inplace
+#   2. Install: pip install -e . --no-build-isolation
+#
+# Note: The --compiler flag only works with build or build_ext commands, not install
+#       For one-step: python setup.py build_ext --compiler=mingw32 install
+#
+# MinGW Compatibility:
+#   setup.py automatically fixes Cython-generated C code for MinGW compatibility.
+#   The fix addresses an enum initialization issue that causes compilation errors
+#   with strict C compilers like MinGW GCC.
+
+[metadata]
+license_files = LICENSE
+
+[bdist_wheel]
+universal = 0

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,37 @@
 from setuptools import setup, find_packages
 from setuptools.extension import Extension
 from os.path import join, exists, sep
+import re
+
+def fix_cython_c_file(filepath):
+    """
+    Fix Cython-generated C files for MinGW compatibility.
+    
+    Cython generates a compile-time check using enum that is not compatible
+    with strict C compilers like MinGW GCC. This function removes the
+    problematic check to allow compilation.
+    """
+    if not exists(filepath):
+        return
+    try:
+        with open(filepath, 'r', encoding='utf-8') as f:
+            content = f.read()
+        
+        # Fix SIZEOF_VOID_P check that causes compilation error with MinGW
+        # The generated code: enum { __pyx_check_sizeof_voidp = 1 / (int)(SIZEOF_VOID_P == sizeof(void*)) };
+        # causes "error: enumerator value is not an integer constant" in MinGW GCC
+        pattern = r'enum\s*\{\s*__pyx_check_sizeof_voidp\s*=\s*1\s*/\s*\(int\)\(SIZEOF_VOID_P\s*==\s*sizeof\(void\*\)\)\s*\};'
+        if re.search(pattern, content):
+            content = re.sub(
+                pattern,
+                '/* __pyx_check_sizeof_voidp check disabled for MinGW compatibility */',
+                content
+            )
+            with open(filepath, 'w', encoding='utf-8') as f:
+                f.write(content)
+            print(f"Fixed MinGW compatibility issue in {filepath}")
+    except Exception as e:
+        print(f"Warning: Failed to fix {filepath}: {e}")
 
 try:
     from Cython.Build import cythonize
@@ -16,13 +47,41 @@ try:
             cythonize_flag = False
             break
     if cythonize_flag:
-        ext_modules = cythonize(pyx_paths)
+        extensions = []
+        for _pyx in pyx_paths:
+            name = _pyx.rstrip(".pyx").replace(sep, ".")
+            ext = Extension(
+                name,
+                [_pyx],
+                include_dirs=[np.get_include()],
+                define_macros=[
+                    ('NPY_NO_DEPRECATED_API', 'NPY_1_7_API_VERSION'),
+                ]
+            )
+            extensions.append(ext)
+        ext_modules = cythonize(
+            extensions,
+            compiler_directives={
+                'language_level': '3',
+            }
+        )
+        
+        # 修复生成的 C 文件
+        for _pyx in pyx_paths:
+            c_file = _pyx.replace(".pyx", ".c")
+            fix_cython_c_file(c_file)
     else:
         ext_modules = list()
         for _pyx in pyx_paths:
             name = _pyx.rstrip(".pyx").replace(sep, ".")
             source = _pyx.replace(".pyx", ".c")
-            ext_modules.append(Extension(name, [source]))
+            ext = Extension(
+                name,
+                [source],
+                include_dirs=[np.get_include()],
+                define_macros=[('NPY_NO_DEPRECATED_API', 'NPY_1_7_API_VERSION')]
+            )
+            ext_modules.append(ext)
     include_dirs = [np.get_include()]
 except ImportError:
     ext_modules = None
@@ -40,9 +99,10 @@ setup(
     author_email="dpy274555447@gmail.com",
     packages=find_packages(),
     include_package_data=True,
-    platforms="Windows",
+    platforms=["Windows", "Linux", "MacOS"],
     python_requires=">=3.9",
     install_requires=[
+        "numpy>=1.20", 
         "metpy>=0.8",
         "cartopy>=0.15",
         "pyshp!=2.0.0, !=2.0.1",


### PR DESCRIPTION
修复了  https://github.com/CyanideCN/PyCINRAD/issues/128

# 主要解决了：
问题1:使用 NumPy 2.x 环境时导入 PyCINRAD 遇到错误;根本原因：
NumPy 2.0 改变了 C API 的 ABI（Application Binary Interface）
使用 NumPy 1.x 编译的扩展模块无法在 NumPy 2.x 环境中运行
需要使用 NumPy 稳定 API (NPY_1_7_API_VERSION) 来实现跨版本兼容
问题2: MinGW-w64 编译失败
Windows 用户使用 MinGW-w64 编译时遇到错误：

```
cinrad\_utils.c:414:12: error: enumerator value for '__pyx_check_sizeof_voidp' 
is not an integer constant
```
根本原因：
Cython 生成的编译时检查代码不符合 C 标准
MinGW GCC 严格遵守标准，拒绝编译
MSVC 编译器较为宽松，可以通过

本次修改通过在 Cython 源文件中使用 NumPy 1.7 稳定 API（NPY_1_7_API_VERSION）实现了对 NumPy 1.20+ 和 2.x 的跨版本兼容性，同时在 setup.py 中添加自动修复逻辑，使用正则表达式删除 Cython 生成的不符合 C 标准的 enum 检查代码，从而解决了 MinGW GCC 编译失败的问题，最终实现了一次编译即可在所有主流平台（Windows MSVC/MinGW、Linux、macOS）和不同 NumPy 版本下正常运行的目标。