### PR TITLE
fix: fail when build from source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,34 +5,27 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   build:
-
     runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        shell: bash -l {0}
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "windows-latest"]
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
-          auto-update-conda: true
           python-version: ${{ matrix.python-version }}
-          environment-file: environment.yaml
-          activate-environment: build
+          cache: "pip"
       - name: Build
         run: |
-          python -m pip install --upgrade setuptools
-          python -m pip install --upgrade wheel
-          python -m pip install --upgrade numpy>=2.0
-          python setup.py bdist_wheel
+          python -m pip install build
+          python -m build --wheel
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         if: ${{ !github.head_ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-          cache: "pip"
       - name: Build
         run: |
           python -m pip install build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,6 @@ jobs:
     - uses: actions/setup-python@v6
       with:
         python-version: "3.11"
-        cache: "pip"
     - name: Install
       run: python -m pip install .
     - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,26 +5,21 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
-    - uses: conda-incubator/setup-miniconda@v2
+      uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
       with:
-        auto-update-conda: true
         python-version: "3.11"
-        environment-file: environment.yaml
-        activate-environment: build
+        cache: "pip"
     - name: Install
-      run: |
-        python -m pip install --upgrade setuptools
-        python -m pip install --upgrade numpy>=2.0
-        python -m pip install .
+      run: python -m pip install .
     - name: Run tests
       run: |
         python -m pip install pytest

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Downloads](https://pepy.tech/badge/cinrad)](https://pepy.tech/project/cinrad)
 [![DOI](https://zenodo.org/badge/139155365.svg)](https://zenodo.org/badge/latestdoi/139155365)
 
-Decode CINRAD (China New Generation Weather Radar) data and visualize. 
+Decode CINRAD (China New Generation Weather Radar) data and visualize.
 
 To check out live examples and docs, visit [pycinrad.cn](https://pycinrad.cn/).
 
@@ -23,7 +23,9 @@ pip install cinrad
 You can also download from github page and build from source
 
 ```
-python setup.py install
+git clone https://github.com/CyanideCN/PyCINRAD.git
+cd PyCINRAD
+pip install .
 ```
 
 ## Modules

--- a/README_zh.md
+++ b/README_zh.md
@@ -4,7 +4,7 @@
 [![Downloads](https://pepy.tech/badge/cinrad)](https://pepy.tech/project/cinrad)
 [![DOI](https://zenodo.org/badge/139155365.svg)](https://zenodo.org/badge/latestdoi/139155365)
 
-Decode CINRAD (China New Generation Weather Radar) data and visualize. 
+Decode CINRAD (China New Generation Weather Radar) data and visualize.
 
 查看示例，请访问官网 [pycinrad.cn](https://pycinrad.cn/).
 
@@ -26,9 +26,9 @@ pip install cinrad
 
 或在此页面下载并执行
 ```
-git clone https://github.com/CyanideCN/PyCINRAD.git    
-cd PyCINRAD  
-python setup.py install
+git clone https://github.com/CyanideCN/PyCINRAD.git
+cd PyCINRAD
+pip install .
 ```
 
 ## 模块介绍

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = [
+    "setuptools>=70.1",
+    "numpy",
+    "cython>0.15",
+]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,9 @@
-from setuptools import setup, find_packages
+from os.path import join, sep
+from setuptools import find_packages, setup
 from setuptools.extension import Extension
-from os.path import join, exists, sep
-import numpy as np
 
-try:
-    from Cython.Build import cythonize
-    USE_CYTHON = True
-except ImportError:
-    USE_CYTHON = False
+import numpy as np
+from Cython.Build import cythonize
 
 macros = [("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")]
 
@@ -16,7 +12,7 @@ pyx_paths = [
     join("cinrad", "correct", "_unwrap_2d"),
 ]
 
-ext_suffix = ".pyx" if USE_CYTHON else ".c"
+ext_suffix = ".pyx"
 
 ext_modules = [
     Extension(
@@ -26,8 +22,7 @@ ext_modules = [
     ) for path in pyx_paths
 ]
 
-if USE_CYTHON:
-    ext_modules = cythonize(ext_modules)
+ext_modules = cythonize(ext_modules)
 
 data_pth = join("cinrad", "data")
 
@@ -41,7 +36,7 @@ setup(
     author_email="dpy274555447@gmail.com",
     packages=find_packages(),
     include_package_data=True,
-    platforms="Windows",
+    platforms=["Windows", "Linux", "MacOS"],
     python_requires=">=3.9",
     install_requires=[
         "metpy>=0.8",


### PR DESCRIPTION
问题：在 linux 上下载 cinrad 包时因为没有 whl 文件，只能从源码开始构建，然后因为缺失 numpy 和 cython 依赖而失败。
目标：没有 whl 或者本地安装时都能直接安装/构建成功。

改动：
- 新增 `pyproject.toml`，填入构建时所需的 setuptools、numpy、cython 依赖
- 去掉 `setup.py` 当没有安装 cython 时直接从 c 代码编译的行为，因为：
  - `.gitignore` 里声明了忽略 c 代码，导致 `git clone` 下来后还是要安装 cython
  - c 代码是根据 numpy 和 cython 版本自动生成的，例如 pypi 下载的源码里 c 代码是用 numpy v1 生成的，导致构建和运行时必须使用 numpy v1 依赖
  - 强制要求安装 cython 有助于避免踩到第二个坑
- README 中用 `pip install .` 替代 `python setup.py`，前者会自动根据 `pyproject.toml` 安装构建时依赖
- 修改 `.github` 目录下的 CI 文件：
  - `python -m pip` 和 `python -m build` 现在都会自动安装构建时依赖
  - 构建时不需要 conda 以及 `environment.yaml` 中那么多依赖，所以改用简单的 `setup-python` action，CI 耗时从 5 分钟降到 1 分钟
  - 加入 macos 平台

`bld.bat` 和 `build.sh` 似乎是本地运行的脚本，里面仍然用的 `python setup.py`。
